### PR TITLE
Display name of edited user, not logged in user

### DIFF
--- a/src/sentry/templates/sentry/admin/users/edit.html
+++ b/src/sentry/templates/sentry/admin/users/edit.html
@@ -9,7 +9,7 @@
 
 {% block main %}
     <section class="body">
-        <h3>User Details <small>{{ user.username }}</small></h3>
+        <h3>User Details <small>{{ the_user.username }}</small></h3>
         <form action="" method="post">
             {% csrf_token %}
             {{ form|as_crispy_errors }}


### PR DESCRIPTION
I think when editing a user, the email/username of the user being edited should be shown, not the one of the user doing the editing.